### PR TITLE
Add branch selection to deploy script

### DIFF
--- a/backend/quadcore.ini
+++ b/backend/quadcore.ini
@@ -4,9 +4,7 @@ master = true
 processes = 5
 
 socket = quadcore.sock
-chmod-socket = 664
-uid = www-data
-gid = www-data
+chmod-socket = 666
 vacuum = true
 
 die-on-term = true

--- a/backend/quadcore.ini
+++ b/backend/quadcore.ini
@@ -4,8 +4,7 @@ master = true
 processes = 5
 
 socket = quadcore.sock
-chmod-socket = 660
+chmod-socket = 664
 vacuum = true
 
 die-on-term = true
-

--- a/backend/quadcore.ini
+++ b/backend/quadcore.ini
@@ -5,6 +5,8 @@ processes = 5
 
 socket = quadcore.sock
 chmod-socket = 664
+uid = www-data
+gid = www-data
 vacuum = true
 
 die-on-term = true

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Deploy Script for Frontend and Backend
-ssh -tt ubuntu@quadcore.news 'bash -s' << 'DEPLOY'
+ssh -tt ubuntu@quadcore.news BRANCH=$1 'bash -s' << 'DEPLOY'
 sudo systemctl daemon-reload
 sudo systemctl stop nginx
 sudo systemctl stop quadcore
@@ -8,7 +8,7 @@ sudo systemctl stop quadcore
 cd /var/www
 sudo rm -rf quadcore.news
 
-sudo git clone https://github.com/kmu-sv/quadcore-serving.git
+sudo git clone https://github.com/kmu-sv/quadcore-serving.git -b $BRANCH
 sudo mv quadcore-serving/frontend quadcore.news
 sudo mv quadcore-serving/backend quadcore.news/quadcore
 sudo cp maintenance/.env quadcore.news/quadcore/.env

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -1,19 +1,18 @@
 #!/bin/bash
 # Deploy Script for Frontend and Backend
 ssh -tt ubuntu@quadcore.news 'bash -s' << 'DEPLOY'
+sudo systemctl daemon-reload
 sudo systemctl stop nginx
 sudo systemctl stop quadcore
 
 cd /var/www
 sudo rm -rf quadcore.news
 
-git clone https://github.com/kmu-sv/quadcore-serving.git
+sudo git clone https://github.com/kmu-sv/quadcore-serving.git
 sudo mv quadcore-serving/frontend quadcore.news
 sudo mv quadcore-serving/backend quadcore.news/quadcore
-sudo mv maintenance/.env quadcore.news/quadcore/.env
+sudo cp maintenance/.env quadcore.news/quadcore/.env
 sudo rm -rf quadcore-serving
-
-sudo chmod 755 quadcore.news
 
 sudo apt-get install python3-dev python3-pip
 sudo pip3 install -r quadcore.news/quadcore/requirements.txt
@@ -21,5 +20,7 @@ sudo pip3 install -r quadcore.news/quadcore/requirements.txt
 sudo systemctl daemon-reload
 sudo systemctl start nginx
 sudo systemctl start quadcore
+sudo chmod 755 quadcore.news
+
 exit
 DEPLOY

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -14,13 +14,14 @@ sudo mv quadcore-serving/backend quadcore.news/quadcore
 sudo cp maintenance/.env quadcore.news/quadcore/.env
 sudo rm -rf quadcore-serving
 
+sudo chmod 755 quadcore.news
+
 sudo apt-get install python3-dev python3-pip
 sudo pip3 install -r quadcore.news/quadcore/requirements.txt
 
 sudo systemctl daemon-reload
 sudo systemctl start nginx
 sudo systemctl start quadcore
-sudo chmod 755 quadcore.news
 
 exit
 DEPLOY


### PR DESCRIPTION
I added branch selection to `deploy/deploy` script.

Branch name will be pass to the server with temporary environment variable and set to `git clone` command.

From now on, deployer must clarify the target branch name like `./deploy master` or `./deploy feature/harry/deploy-branch`.

Please take a look!